### PR TITLE
feat: #229 Add duration to Audio

### DIFF
--- a/src/main/java/ai/elimu/model/v1/gson/content/multimedia/AudioGson.java
+++ b/src/main/java/ai/elimu/model/v1/gson/content/multimedia/AudioGson.java
@@ -10,6 +10,8 @@ public class AudioGson extends MultimediaGson {
     
     private String transcription;
     
+    private Long durationMs;
+    
     private AudioFormat audioFormat;
 
     public String getTranscription() {
@@ -18,6 +20,14 @@ public class AudioGson extends MultimediaGson {
 
     public void setTranscription(String transcription) {
         this.transcription = transcription;
+    }
+    
+    public Long getDurationMs() {
+        return durationMs;
+    }
+    
+    public void setDurationMs(Long durationMs) {
+        this.durationMs = durationMs;
     }
 
     public AudioFormat getAudioFormat() {

--- a/src/main/java/ai/elimu/model/v1/gson/content/multimedia/AudioGson.java
+++ b/src/main/java/ai/elimu/model/v1/gson/content/multimedia/AudioGson.java
@@ -10,8 +10,6 @@ public class AudioGson extends MultimediaGson {
     
     private String transcription;
     
-    private Long durationMs;
-    
     private AudioFormat audioFormat;
 
     public String getTranscription() {
@@ -20,14 +18,6 @@ public class AudioGson extends MultimediaGson {
 
     public void setTranscription(String transcription) {
         this.transcription = transcription;
-    }
-    
-    public Long getDurationMs() {
-        return durationMs;
-    }
-    
-    public void setDurationMs(Long durationMs) {
-        this.durationMs = durationMs;
     }
 
     public AudioFormat getAudioFormat() {

--- a/src/main/java/ai/elimu/model/v2/gson/content/AudioGson.java
+++ b/src/main/java/ai/elimu/model/v2/gson/content/AudioGson.java
@@ -16,6 +16,8 @@ public class AudioGson extends ContentGson {
     private String bytesUrl;
     
     private Integer bytesSize;
+    
+    private Long durationMs;
 
     public String getTitle() {
         return title;
@@ -55,5 +57,13 @@ public class AudioGson extends ContentGson {
 
     public void setBytesSize(Integer bytesSize) {
         this.bytesSize = bytesSize;
+    }
+    
+    public Long getDurationMs() {
+        return durationMs;
+    }
+    
+    public void setDurationMs(Long durationMs) {
+        this.durationMs = durationMs;
     }
 }


### PR DESCRIPTION
- This field will be used by Android apps that need to know the duration of an audio recording, in order to display a progress indicator in the UI for example.
- The field will be populated by the webapp's [AudioMetadataExtractionHelper](https://github.com/elimu-ai/webapp/blob/master/src/main/java/ai/elimu/util/AudioMetadataExtractionHelper.java) (https://github.com/elimu-ai/webapp/projects/6#card-58548810).