### PR TITLE
fix: revert gson upgrade from 2.11.0 to 2.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.12.1</version>
+      <version>2.11.0</version>
     </dependency>
     <!-- Lombok -->
     <dependency>


### PR DESCRIPTION
Revert changes  https://github.com/elimu-ai/model/pull/305/commits/f6c162205ff1ccbb7d8315322c5ff4ab6b92bc3c

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #314

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* Compilation fails in Android apps that upgrade to version 2.0.76 or higher of the `model` library.

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* Perform a new release of the `model` library, and try using it in one of the Android apps.

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*
