### PR TITLE
379 handle thai tone marks

### DIFF
--- a/src/main/java/ai/elimu/model/v2/gson/content/WordGson.java
+++ b/src/main/java/ai/elimu/model/v2/gson/content/WordGson.java
@@ -43,19 +43,40 @@ public class WordGson extends ContentGson {
       // Re-order letter sequences
       for (int i = 0; i < letterSequences.size(); i++) {
           String letterSequence = letterSequences.get(i);
-          if (letterSequence.contains("◌")) {
+          if (letterSequence.contains("◌◌")) {
               if (letterSequence.endsWith("◌◌")) {
                   // E.g. 'ใ◌◌'
                   
                   // Remove the two dotted circles (◌◌)
                   // <'ค','ร','ใ◌◌'> --> <'ค','ร','ใ'>
-                  letterSequences.set(i, letterSequence.substring(0, letterSequence.length() - 2));
+                  letterSequence = letterSequence.substring(0, letterSequence.length() - 2);
+                  letterSequences.set(i, letterSequence);
 
                   // Shift the letter sequence two positions to the left
                   // <'ค','ร','ใ'> --> <'ใ','ค','ร'>
                   Collections.swap(letterSequences, i, i - 1);
                   Collections.swap(letterSequences, i - 1, i - 2);
-              } else if (letterSequence.endsWith("◌")) {
+              } else {
+                // E.g. 'เ◌◌า'
+
+                // Expect to find two letter sequences to the left
+                // <'จ', '◌้', 'เ◌◌า'>
+                String letterSequence1 = letterSequences.get(i - 2);
+                String letterSequence2 = letterSequences.get(i - 1);
+
+                // Replace the two dotted circles (◌◌) with the two letter sequences
+                // <'จ', '◌้', 'เ◌◌า'> --> <'จ', '◌้', 'เจ◌้า'>
+                letterSequence = letterSequence.replaceFirst("◌", letterSequence1);
+                letterSequence = letterSequence.replaceFirst("◌", letterSequence2);
+                letterSequences.set(i, letterSequence);
+
+                // Delete the two letter sequences
+                // <'จ', '◌้', 'เจ◌้า'> --> <'เจ◌้า'>
+                letterSequences.remove(0);
+                letterSequences.remove(0);
+              }
+          } else if (letterSequence.contains("◌")) {
+              if (letterSequence.endsWith("◌")) {
                   // E.g. 'ไ◌'
                   
                   // Remove the dotted circle (◌)
@@ -85,7 +106,7 @@ public class WordGson extends ContentGson {
 
                 // Delete the consonant
                 // <'ข','เขา'> --> <'เขา'>
-                letterSequences.remove(i - 1);
+                letterSequences.remove(0);
               }
           }
       }

--- a/src/main/java/ai/elimu/model/v2/gson/content/WordGson.java
+++ b/src/main/java/ai/elimu/model/v2/gson/content/WordGson.java
@@ -33,63 +33,63 @@ public class WordGson extends ContentGson {
    */
   public String toString() {
       // Convert from List<LetterSoundGson> to List<String>
-      List<String> wordLetters = new ArrayList<>();
+      List<String> letterSequences = new ArrayList<>();
       for (LetterSoundGson letterSound : letterSounds) {
           List<LetterGson> letterGsons = letterSound.getLetters();
           String letterSoundLetters = letterGsons.stream().map(LetterGson::getText).collect(Collectors.joining());
-          wordLetters.add(letterSoundLetters);
+          letterSequences.add(letterSoundLetters);
       }
 
-      // Re-order letters
-      for (int i = 0; i < wordLetters.size(); i++) {
-          String wordLetter = wordLetters.get(i);
-          if (wordLetter.contains("◌")) {
-              if (wordLetter.endsWith("◌◌")) {
+      // Re-order letter sequences
+      for (int i = 0; i < letterSequences.size(); i++) {
+          String letterSequence = letterSequences.get(i);
+          if (letterSequence.contains("◌")) {
+              if (letterSequence.endsWith("◌◌")) {
                   // E.g. 'ใ◌◌'
                   
                   // Remove the two dotted circles (◌◌)
                   // <'ค','ร','ใ◌◌'> --> <'ค','ร','ใ'>
-                  wordLetters.set(i, wordLetter.substring(0, wordLetter.length() - 2));
+                  letterSequences.set(i, letterSequence.substring(0, letterSequence.length() - 2));
 
-                  // Shift the letter two positions to the left
+                  // Shift the letter sequence two positions to the left
                   // <'ค','ร','ใ'> --> <'ใ','ค','ร'>
-                  Collections.swap(wordLetters, i, i - 1);
-                  Collections.swap(wordLetters, i - 1, i - 2);
-              } else if (wordLetter.endsWith("◌")) {
+                  Collections.swap(letterSequences, i, i - 1);
+                  Collections.swap(letterSequences, i - 1, i - 2);
+              } else if (letterSequence.endsWith("◌")) {
                   // E.g. 'ไ◌'
                   
                   // Remove the dotted circle (◌)
                   // <'ป','ไ◌'> --> <'ป','ไ'>
-                  wordLetters.set(i, wordLetter.substring(0, wordLetter.length() - 1));
+                  letterSequences.set(i, letterSequence.substring(0, letterSequence.length() - 1));
 
-                  // Shift the letter one position to the left
+                  // Shift the letter sequence one position to the left
                   // <'ป','ไ'> --> <'ไ','ป'>
-                  Collections.swap(wordLetters, i, i - 1);
-              } else if (wordLetter.startsWith("◌")) {
+                  Collections.swap(letterSequences, i, i - 1);
+              } else if (letterSequence.startsWith("◌")) {
                   // E.g '◌ะ'
                   
                   // Remove the dotted circle (◌)
                   // <'จ','◌ะ'> --> <'จ','ะ'>
-                  wordLetters.set(i, wordLetter.substring(1, wordLetter.length()));
+                  letterSequences.set(i, letterSequence.substring(1, letterSequence.length()));
               } else {
                 // E.g. 'เ◌า'
 
                 // Expect to find a consonant one position to the left
                 // <'ข','เ◌า'>
-                String consonant = wordLetters.get(i - 1);
+                String consonant = letterSequences.get(i - 1);
 
                 // Replace the dotted circle (◌) with the consonant
                 // <'ข','เ◌า'> --> <'ข','เขา'>
-                wordLetter = wordLetter.replaceFirst("◌", consonant);
-                wordLetters.set(i, wordLetter);
+                letterSequence = letterSequence.replaceFirst("◌", consonant);
+                letterSequences.set(i, letterSequence);
 
                 // Delete the consonant
                 // <'ข','เขา'> --> <'เขา'>
-                wordLetters.remove(i - 1);
+                letterSequences.remove(i - 1);
               }
           }
       }
 
-      return wordLetters.stream().collect(Collectors.joining());
+      return letterSequences.stream().collect(Collectors.joining());
   }
 }

--- a/src/test/java/ai/elimu/model/v2/gson/content/WordGsonTest.java
+++ b/src/test/java/ai/elimu/model/v2/gson/content/WordGsonTest.java
@@ -134,4 +134,62 @@ public class WordGsonTest {
 
         assertEquals("ใคร", wordKhrai.toString());
     }
+
+    /**
+     * ['ต', '◌่', 'แ◌'] --> "แต่"
+     */
+    @Test
+    public void testToString_tɛ̀ɛ() {
+        LetterGson letterTooTaw = new LetterGson();
+        letterTooTaw.setText("ต");
+
+        LetterGson diacriticMaaiEk = new LetterGson();
+        diacriticMaaiEk.setText("◌่");
+
+        LetterGson letterSaraAe = new LetterGson();
+        letterSaraAe.setText("แ◌◌");
+
+        LetterSoundGson letterSoundT = new LetterSoundGson();
+        letterSoundT.setLetters(Arrays.asList(letterTooTaw));
+
+        LetterSoundGson letterSoundLowTone = new LetterSoundGson();
+        letterSoundLowTone.setLetters(Arrays.asList(diacriticMaaiEk));
+
+        LetterSoundGson letterSoundAe = new LetterSoundGson();
+        letterSoundAe.setLetters(Arrays.asList(letterSaraAe));
+
+        WordGson wordTɛ̀ɛ = new WordGson();
+        wordTɛ̀ɛ.setLetterSounds(Arrays.asList(letterSoundT, letterSoundLowTone, letterSoundAe));
+
+        assertEquals("แต่", wordTɛ̀ɛ.toString());
+    }
+
+    /**
+     * ['จ', '◌้', 'เ◌◌า'] --> "เจ้า"
+     */
+    @Test
+    public void testToString_câaw() {
+        LetterGson letterJooJaan = new LetterGson();
+        letterJooJaan.setText("จ");
+
+        LetterGson diacriticMaaiThoo = new LetterGson();
+        diacriticMaaiThoo.setText("◌้");
+
+        LetterGson letterSaraAw = new LetterGson();
+        letterSaraAw.setText("เ◌◌า");
+
+        LetterSoundGson letterSoundJoJaan = new LetterSoundGson();
+        letterSoundJoJaan.setLetters(Arrays.asList(letterJooJaan));
+
+        LetterSoundGson letterSoundFallingTone = new LetterSoundGson();
+        letterSoundFallingTone.setLetters(Arrays.asList(diacriticMaaiThoo));
+
+        LetterSoundGson letterSoundAw = new LetterSoundGson();
+        letterSoundAw.setLetters(Arrays.asList(letterSaraAw));
+
+        WordGson wordCâaw = new WordGson();
+        wordCâaw.setLetterSounds(Arrays.asList(letterSoundJoJaan, letterSoundFallingTone, letterSoundAw));
+
+        assertEquals("เจ้า", wordCâaw.toString());
+    }
 }


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #379

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Thai word composition accuracy by enhancing reordering and vowel/placeholder handling in complex patterns (e.g., เ◌า, เ◌◌า).
  * Corrects rendering for specific words and similar cases, ensuring expected output in the UI (e.g., แต่, เจ้า).

* **Tests**
  * Added unit tests validating reconstruction of multi-segment Thai words, including cases like “แต่” and “เจ้า”, to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->